### PR TITLE
Add payment gateway integration

### DIFF
--- a/api-gateway/public/src/pages/Checkout.tsx
+++ b/api-gateway/public/src/pages/Checkout.tsx
@@ -58,6 +58,30 @@ const Checkout = () => {
     console.log('Processing payment...', { planType, paymentMethod, formData });
   };
 
+  const handleStripePayment = async () => {
+    const res = await fetch('/payments/stripe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planId: planType, amount: selectedPlan.price }),
+    });
+    const data = await res.json();
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  };
+
+  const handlePaypalPayment = async () => {
+    const res = await fetch('/payments/paypal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planId: planType, amount: selectedPlan.price }),
+    });
+    const data = await res.json();
+    if (data.approvalUrl) {
+      window.location.href = data.approvalUrl;
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
       <div className="container mx-auto px-4 py-8">
@@ -263,14 +287,21 @@ const Checkout = () => {
                     <span>${selectedPlan.price}{selectedPlan.period}</span>
                   </div>
 
-                  <Button 
-                    type="submit" 
+                  <Button
+                    type="submit"
                     form="checkout-form"
                     className="w-full bg-gradient-primary hover:opacity-90 transition-opacity"
                     onClick={handleSubmit}
                   >
                     <Lock className="h-4 w-4 mr-2" />
                     Completar Suscripción
+                  </Button>
+
+                  <Button className="w-full mt-2" onClick={handleStripePayment}>
+                    Pagar con Stripe
+                  </Button>
+                  <Button className="w-full mt-2" onClick={handlePaypalPayment}>
+                    Pagar con PayPal
                   </Button>
 
                   <div className="text-center">

--- a/modules/payments/payments.js
+++ b/modules/payments/payments.js
@@ -1,15 +1,61 @@
 const express = require('express');
 const router = express.Router();
+const Stripe = require('stripe');
+const paypal = require('@paypal/checkout-server-sdk');
 
-// stub payment endpoints
-router.post('/stripe', (req, res) => {
-  // pretend to process payment with Stripe
-  res.json({ status: 'success', provider: 'stripe' });
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2024-04-10',
 });
 
-router.post('/paypal', (req, res) => {
-  // pretend to process payment with PayPal
-  res.json({ status: 'success', provider: 'paypal' });
+const paypalEnv = new paypal.core.SandboxEnvironment(
+  process.env.PAYPAL_CLIENT_ID || '',
+  process.env.PAYPAL_CLIENT_SECRET || ''
+);
+const paypalClient = new paypal.core.PayPalHttpClient(paypalEnv);
+
+router.post('/stripe', async (req, res) => {
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: { name: req.body.planId || 'plan' },
+            unit_amount: Math.round(req.body.amount * 100),
+          },
+          quantity: 1,
+        },
+      ],
+      success_url: `${req.headers.origin}/success`,
+      cancel_url: `${req.headers.origin}/cancel`,
+    });
+    res.json({ url: session.url });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/paypal', async (req, res) => {
+  const request = new paypal.orders.OrdersCreateRequest();
+  request.requestBody({
+    intent: 'CAPTURE',
+    purchase_units: [
+      {
+        amount: { currency_code: 'USD', value: req.body.amount },
+      },
+    ],
+  });
+
+  try {
+    const order = await paypalClient.execute(request);
+    const approve = order.result.links.find((l) => l.rel === 'approve');
+    res.json({ approvalUrl: approve.href });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
 });
 
 module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,43 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@paypal/checkout-server-sdk": "^1.0.3",
+        "@stripe/stripe-js": "^7.5.0",
         "@supabase/supabase-js": "^2.52.0",
-        "express": "^5.1.0"
+        "dotenv": "^16.3.1",
+        "express": "^5.1.0",
+        "stripe": "^18.3.0"
+      }
+    },
+    "node_modules/@paypal/checkout-server-sdk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@paypal/checkout-server-sdk/-/checkout-server-sdk-1.0.3.tgz",
+      "integrity": "sha512-UEdq8akEdMz0Vs4qoQFU2gMp8PpyE/HKyMwiZuK4vIWUKl8jfd1fWKjQN5cDFm9NkFUIp5U7h++rdMOVj9WMNA==",
+      "deprecated": "Package no longer supported. The author suggests using the @paypal/paypal-server-sdk package instead: https://www.npmjs.com/package/@paypal/paypal-server-sdk. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "SEE LICENSE IN https://github.com/paypal/Checkout-NodeJS-SDK/blob/master/LICENSE",
+      "dependencies": {
+        "@paypal/paypalhttp": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@paypal/paypalhttp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@paypal/paypalhttp/-/paypalhttp-1.0.1.tgz",
+      "integrity": "sha512-DC7AHxTT7drF6dUi3YaFdPVuT15sIkpD5H2eHmdtFgxM4UanS1o1ZDfMhR9mpxd8o+X6pz2r+EZVRRq+n1cssQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.5.0.tgz",
+      "integrity": "sha512-Cq3KKe+G1o7PSBMbmrgpT2JgBeyH2THHr3RdIX2MqF7AnBuspIMgtZ3ktcCgP7kZsTMvnmWymr7zZCT1zeWbMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -246,6 +281,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -887,6 +934,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.3.0.tgz",
+      "integrity": "sha512-FkxrTUUcWB4CVN2yzgsfF/YHD6WgYHduaa7VmokCy5TLCgl5UNJkwortxcedrxSavQ8Qfa4Ir4JxcbIYiBsyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@paypal/checkout-server-sdk": "^1.0.3",
+    "@stripe/stripe-js": "^7.5.0",
     "@supabase/supabase-js": "^2.52.0",
     "dotenv": "^16.3.1",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "stripe": "^18.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- integrate Stripe and PayPal payment providers in the backend
- expose new pay buttons in the checkout page
- install Stripe and PayPal SDK dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687fadb38d98832ba633d2b0c8f63f4b