### PR TITLE
Add Google Cloud Run deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,20 @@ hook stored in the `RENDER_DEPLOY_HOOK` secret.
 The project can be hosted on [Render](https://render.com/) or any other cloud
 provider capable of running a Docker container. Configure the deploy hook in the
 repository secrets and every successful build of the `main` branch will publish
-a new version.
+ a new version.
+
+### Deploying to Google Cloud Run
+
+The directory `deployments/google-cloud` contains a `cloudbuild.yaml` file that
+builds the Docker image defined in `docker/Dockerfile`, pushes it to Google
+Container Registry and deploys it to **Cloud Run**. Both the Express API and the
+React front-end run from the same container.
+
+To deploy using the Google Cloud CLI:
+
+```bash
+gcloud builds submit --config deployments/google-cloud/cloudbuild.yaml .
+```
+
+Once the build completes, Cloud Run prints the service URL where the application
+is available.

--- a/deployments/google-cloud/README.md
+++ b/deployments/google-cloud/README.md
@@ -1,0 +1,20 @@
+# Deploying to Google Cloud Run
+
+These files provide a simple setup for deploying the monolithic container (which serves both the Express API and React front-end) to **Google Cloud Run** using Cloud Build.
+
+1. Enable Cloud Run and Cloud Build in your Google Cloud project.
+2. Set up Artifact Registry or Container Registry permissions so Cloud Build can push images.
+3. Trigger a build using the `cloudbuild.yaml` file. This will:
+   - Build the Docker image using `docker/Dockerfile`.
+   - Push the image to `gcr.io/$PROJECT_ID`.
+   - Deploy it to Cloud Run as `learnpro-service` in region `us-central1`.
+
+The service will expose both the API and the front-end on the same endpoint.
+
+To trigger the build manually:
+
+```bash
+gcloud builds submit --config deployments/google-cloud/cloudbuild.yaml .
+```
+
+After deployment, Cloud Run will output the service URL. Navigate to that URL to access the application.

--- a/deployments/google-cloud/cloudbuild.yaml
+++ b/deployments/google-cloud/cloudbuild.yaml
@@ -1,0 +1,10 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/learnpro', '-f', 'docker/Dockerfile', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/learnpro']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args: ['run', 'deploy', 'learnpro-service', '--image', 'gcr.io/$PROJECT_ID/learnpro', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+images:
+  - 'gcr.io/$PROJECT_ID/learnpro'


### PR DESCRIPTION
## Summary
- provide a Cloud Build configuration for deploying to Cloud Run
- document Cloud Run deployment steps in the new `deployments/google-cloud` folder
- mention Google Cloud Run deployment in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687fcdcdf058832b94d3a7335a71850d