### PR TITLE
Restore google cloud deployment config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,4 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: docker build -t learnpro -f docker/Dockerfile .
-      - name: Trigger Render Deploy
-        if: ${{ github.ref == 'refs/heads/main' && success() }}
-        env:
-          RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
-        run: |
-          if [ -n "$RENDER_DEPLOY_HOOK" ]; then
-            curl -X POST "$RENDER_DEPLOY_HOOK"
-          else
-            echo "RENDER_DEPLOY_HOOK not set"
-          fi
+

--- a/README.md
+++ b/README.md
@@ -139,16 +139,15 @@ The project illustrates several classic design patterns:
 ## Continuous Integration and Deployment
 
 GitHub Actions (`.github/workflows/ci.yml`) runs the Jest tests and builds the
-Docker image on every push or pull request. When commits reach the `main`
-branch the workflow optionally triggers a deployment to Render using a deploy
-hook stored in the `RENDER_DEPLOY_HOOK` secret.
+Docker image on every push or pull request. The workflow only verifies that the
+application and Docker image build correctly and does not perform any automatic
+deployment.
 
 ## Cloud Deployment
 
-The project can be hosted on [Render](https://render.com/) or any other cloud
-provider capable of running a Docker container. Configure the deploy hook in the
-repository secrets and every successful build of the `main` branch will publish
- a new version.
+Applications can be deployed to any provider capable of running a Docker
+container. For Google Cloud Run, a simple Cloud Build configuration is provided
+under `deployments/google-cloud`.
 
 ### Deploying to Google Cloud Run
 

--- a/deployments/google-cloud/README.md
+++ b/deployments/google-cloud/README.md
@@ -1,0 +1,20 @@
+# Deploying to Google Cloud Run
+
+These files provide a simple setup for deploying the monolithic container (which serves both the Express API and React front-end) to **Google Cloud Run** using Cloud Build.
+
+1. Enable Cloud Run and Cloud Build in your Google Cloud project.
+2. Set up Artifact Registry or Container Registry permissions so Cloud Build can push images.
+3. Trigger a build using the `cloudbuild.yaml` file. This will:
+   - Build the Docker image using `docker/Dockerfile`.
+   - Push the image to `gcr.io/$PROJECT_ID`.
+   - Deploy it to Cloud Run as `learnpro-service` in region `us-central1`.
+
+The service will expose both the API and the front-end on the same endpoint.
+
+To trigger the build manually:
+
+```bash
+gcloud builds submit --config deployments/google-cloud/cloudbuild.yaml .
+```
+
+After deployment, Cloud Run will output the service URL. Navigate to that URL to access the application.

--- a/deployments/google-cloud/cloudbuild.yaml
+++ b/deployments/google-cloud/cloudbuild.yaml
@@ -1,0 +1,10 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/learnpro', '-f', 'docker/Dockerfile', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/learnpro']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args: ['run', 'deploy', 'learnpro-service', '--image', 'gcr.io/$PROJECT_ID/learnpro', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+images:
+  - 'gcr.io/$PROJECT_ID/learnpro'


### PR DESCRIPTION
## Summary
- restore `deployments/google-cloud` directory for Cloud Run
- remove Render deploy step from CI pipeline
- clarify README about CI pipeline and Cloud Run deployment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fdc979ddc832bbf9bcb9e5592ec0e