### PR TITLE
Update default port to 8080

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ SUPABASE_URL=http://localhost:54321
 SUPABASE_ANON_KEY=your-local-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ADMIN_EMAILS=admin1@example.com,admin2@example.com,admin3@example.com
-PORT=3000
+PORT=8080
 # Database connection
 DB_HOST=localhost
 DB_NAME=learnpro

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,5 @@ ENV NODE_ENV=production
 
 COPY --from=backend /app .
 
-EXPOSE 3000
+EXPOSE 8080
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install
 npm start
 ```
 
-The server runs on port `3000` by default.
+The server runs on port `8080` by default.
 
 ## Running the front-end
 
@@ -67,10 +67,10 @@ context includes the frontend sources. To build and run:
 
 ```bash
 docker build -t learnpro -f docker/Dockerfile .
-docker run -p 3000:3000 learnpro
+docker run -p 8080:8080 learnpro
 ```
 
-The application will be available on `http://localhost:3000`.
+The application will be available on `http://localhost:8080`.
 
 ## Using Supabase locally
 
@@ -97,7 +97,7 @@ Create a `.env` file in the project root containing the following keys:
 - `SUPABASE_URL` and `SUPABASE_ANON_KEY` – Supabase connection details.
 - `SUPABASE_SERVICE_ROLE_KEY` – service role key for privileged operations.
 - `ADMIN_EMAILS` – comma-separated list of administrator emails.
-- `PORT` – port for the API gateway (defaults to `3000`).
+- `PORT` – port for the API gateway (defaults to `8080`).
 - `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` – database connection information.
 - `ADMIN_ACCOUNTS` – optional `email:password` pairs for initial admin accounts.
 

--- a/api-gateway/index.js
+++ b/api-gateway/index.js
@@ -34,7 +34,8 @@ app.use((req, res) => {
   res.sendFile(path.join(frontendPath, 'index.html'));
 });
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`LearnPro server running on port ${PORT}`);
+const port = process.env.PORT || 8080;
+process.env.PORT = port;
+app.listen(port, () => {
+  console.log(`LearnPro server running on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- set default PORT to 8080
- update Dockerfile to expose 8080
- document the new port in README
- update example `.env`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687fe8616ee8832bb15791212b886b3e