### PR TITLE
Add header to dashboard

### DIFF
--- a/api-gateway/public/src/pages/Dashboard.tsx
+++ b/api-gateway/public/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Header from '@/components/Header';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
@@ -56,6 +57,7 @@ const Dashboard = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
+      <Header />
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
         <div className="mb-8">


### PR DESCRIPTION
## Summary
- display `<Header />` in the dashboard view so the navigation bar appears after login

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ff6f9ea3c832ba4d970c38e428c90