### PR TITLE
Adjust header navigation for guests

### DIFF
--- a/api-gateway/public/src/components/Header.tsx
+++ b/api-gateway/public/src/components/Header.tsx
@@ -50,15 +50,19 @@ const Header = () => {
             <Link to="/courses" className="text-foreground hover:text-primary transition-colors">
               Cursos
             </Link>
-            <Link to="/dashboard" className="text-foreground hover:text-primary transition-colors">
-              Dashboard
-            </Link>
-            <Link to="/subscription" className="text-foreground hover:text-primary transition-colors">
-              Suscripción
-            </Link>
-            <Link to="/profile" className="text-foreground hover:text-primary transition-colors">
-              Perfil
-            </Link>
+            {user && (
+              <>
+                <Link to="/dashboard" className="text-foreground hover:text-primary transition-colors">
+                  Dashboard
+                </Link>
+                <Link to="/subscription" className="text-foreground hover:text-primary transition-colors">
+                  Suscripción
+                </Link>
+                <Link to="/profile" className="text-foreground hover:text-primary transition-colors">
+                  Perfil
+                </Link>
+              </>
+            )}
             <Link to="/contact" className="text-foreground hover:text-primary transition-colors">
               Contacto
             </Link>


### PR DESCRIPTION
## Summary
- show Dashboard, Suscripción and Perfil links only when a user is logged in

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ff8173950832b82eaf183b208b758