### PR TITLE
Implement admin subscription management

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,22 @@ Create a `.env` file in the project root containing the following keys:
 
 
 See `.env` for an example configuration.
+
+### Admin subscription management
+
+Admins can now manage user subscriptions through the `/subscriptions` API.  The
+following endpoints require an `x-user-role: admin` header:
+
+```
+PUT /subscriptions/:id     # update plan, status or dates
+DELETE /subscriptions/:id  # remove a subscription
+```
+
+All users (including admins) can retrieve subscriptions with:
+
+```
+GET /subscriptions/:id
+```
+
+These changes ensure admins share the same subscriptions as regular users and
+any modifications are immediately visible through the API.

--- a/core/application/subscriptionsService.js
+++ b/core/application/subscriptionsService.js
@@ -10,6 +10,19 @@ async function getAllSubscriptions() {
   return subscriptions;
 }
 
+async function getSubscription(id) {
+  if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (error) throw error;
+    return data;
+  }
+  return subscriptions.find((s) => s.id === parseInt(id));
+}
+
 async function addSubscription({ userId, plan, active = true }) {
   if (process.env.SUPABASE_URL) {
     const { data, error } = await supabase
@@ -24,4 +37,43 @@ async function addSubscription({ userId, plan, active = true }) {
   return subscription;
 }
 
-module.exports = { getAllSubscriptions, addSubscription };
+async function updateSubscription(id, updates) {
+  if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .update({
+        plan_id: updates.plan,
+        status: updates.active ? 'active' : 'inactive',
+        start_date: updates.startDate,
+        end_date: updates.endDate,
+      })
+      .eq('id', id)
+      .single();
+    if (error) throw error;
+    return data;
+  }
+  const sub = subscriptions.find((s) => s.id === parseInt(id));
+  if (!sub) throw new Error('Subscription not found');
+  Object.assign(sub, updates);
+  return sub;
+}
+
+async function deleteSubscription(id) {
+  if (process.env.SUPABASE_URL) {
+    const { error } = await supabase.from('subscriptions').delete().eq('id', id);
+    if (error) throw error;
+    return { id };
+  }
+  const index = subscriptions.findIndex((s) => s.id === parseInt(id));
+  if (index === -1) throw new Error('Subscription not found');
+  const [deleted] = subscriptions.splice(index, 1);
+  return deleted;
+}
+
+module.exports = {
+  getAllSubscriptions,
+  getSubscription,
+  addSubscription,
+  updateSubscription,
+  deleteSubscription,
+};

--- a/modules/payments/subscriptions.js
+++ b/modules/payments/subscriptions.js
@@ -2,9 +2,13 @@ const express = require('express');
 const router = express.Router();
 const {
   getAllSubscriptions,
-  addSubscription
+  getSubscription,
+  addSubscription,
+  updateSubscription,
+  deleteSubscription,
 } = require('../../core/application/subscriptionsService');
 const subscriptions = require('../../core/domain/subscriptions');
+const adminCheck = require('../../shared/middleware/adminCheck');
 
 router.get('/', async (req, res) => {
   try {
@@ -19,6 +23,34 @@ router.post('/', async (req, res) => {
   try {
     const subscription = await addSubscription(req.body);
     res.status(201).json(subscription);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const sub = await getSubscription(req.params.id);
+    if (!sub) return res.status(404).json({ error: 'Not found' });
+    res.json(sub);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.put('/:id', adminCheck, async (req, res) => {
+  try {
+    const updated = await updateSubscription(req.params.id, req.body);
+    res.json(updated);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete('/:id', adminCheck, async (req, res) => {
+  try {
+    const deleted = await deleteSubscription(req.params.id);
+    res.json(deleted);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/shared/middleware/adminCheck.js
+++ b/shared/middleware/adminCheck.js
@@ -1,0 +1,5 @@
+module.exports = function (req, res, next) {
+  const role = req.header('x-user-role');
+  if (role === 'admin') return next();
+  res.status(403).json({ error: 'Admin access required' });
+};


### PR DESCRIPTION
## Summary
- allow subscriptions to be updated and deleted
- add middleware to restrict admin routes
- expose admin-only endpoints in the subscriptions router
- document admin management API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68801dea05f4832ba7b7ca67ea177413