### PR TITLE
Fix Docker build by adding env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment configuration for LearnPro
+SUPABASE_URL=http://localhost:54321
+SUPABASE_ANON_KEY=local-anon-key
+SUPABASE_SERVICE_ROLE_KEY=local-service-role-key
+ADMIN_EMAILS=admin1@example.com,admin2@example.com,admin3@example.com
+DB_HOST=localhost
+DB_NAME=learnpro
+DB_USER=postgres
+DB_PASSWORD=postgres
+ADMIN_ACCOUNTS=admin@example.com:password
+STRIPE_SECRET_KEY=sk_test_123
+PAYPAL_CLIENT_ID=test
+PAYPAL_CLIENT_SECRET=test
+PORT=8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm run build
 
 # -------- Build backend and assemble app ---------
 FROM node:18-slim AS backend
+ARG ENV_FILE=.env.example
 WORKDIR /app
 
 COPY package*.json ./
@@ -20,8 +21,8 @@ COPY api-gateway ./api-gateway
 COPY shared ./shared
 COPY database ./database
 
-# Copiar .env para que esté disponible en la siguiente etapa
-COPY .env .env
+# Copy default environment or provided file
+COPY ${ENV_FILE} .env
 
 # Include built frontend assets
 COPY --from=frontend /app/frontend/dist ./api-gateway/public/dist

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ docker build -t learnpro .
 docker run -p 8080:8080 learnpro
 ```
 
+The Dockerfile copies `.env.example` by default. Provide a custom file with
+`--build-arg ENV_FILE=.env` if needed.
+
 The application will be available on `http://localhost:8080`.
 
 ## Using Supabase locally
@@ -92,7 +95,7 @@ To use a hosted Supabase project instead, set the same environment variables to 
 
 ## Environment variables
 
-Create a `.env` file in the project root containing the following keys when running locally:
+Create a `.env` file in the project root containing the following keys when running locally. You can use `.env.example` as a starting point:
 
 - `SUPABASE_URL` and `SUPABASE_ANON_KEY` – Supabase connection details.
 - `SUPABASE_SERVICE_ROLE_KEY` – service role key for privileged operations.
@@ -102,7 +105,7 @@ Create a `.env` file in the project root containing the following keys when runn
 - `ADMIN_ACCOUNTS` – optional `email:password` pairs for initial admin accounts.
 
 
-See `.env` for an example configuration. When running the Docker container in production you can provide these variables using your orchestrator (for example Cloud Run or `docker run -e`).
+See `.env.example` for an example configuration. When running the Docker container in production you can provide these variables using your orchestrator (for example Cloud Run or `docker run -e`).
 
 ## Course management
 


### PR DESCRIPTION
## Summary
- add example environment configuration so builds succeed
- let Dockerfile copy `.env.example` by default with override option
- document env setup and Docker build steps

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68802797bf10832b967d3237640b4c73