### PR TITLE
Enable profile page to fetch user data

### DIFF
--- a/api-gateway/index.js
+++ b/api-gateway/index.js
@@ -20,12 +20,14 @@ const {
 } = require('../modules/payments');
 const notificationsRouter = require('../modules/notifications');
 const progressRouter = require('../modules/products/progress');
+const usersRouter = require('../modules/users');
 app.use("/products", subscriptionAccess, productsRouter);
 app.use("/progress", subscriptionAccess, progressRouter);
 
 app.use("/payments", paymentsRouter);
 app.use('/subscriptions', subscriptionsRouter);
 app.use('/notifications', notificationsRouter);
+app.use('/users', usersRouter);
 app.use('/auth', authRouter);
 
 // Send React app for any other route

--- a/api-gateway/public/src/api/index.ts
+++ b/api-gateway/public/src/api/index.ts
@@ -15,3 +15,11 @@ export async function getCourse(id: number) {
   }
   return res.json();
 }
+
+export async function getUser(id: string) {
+  const res = await fetch(`${API_BASE}/users/${id}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch user');
+  }
+  return res.json();
+}

--- a/api-gateway/public/src/pages/Profile.tsx
+++ b/api-gateway/public/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -9,17 +9,40 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { User, Mail, Calendar, Award, BookOpen, Trophy, Camera } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { getUser } from "@/api";
 
 export default function Profile() {
+  const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState(false);
   const [profile, setProfile] = useState({
-    name: "Ana García",
-    email: "ana.garcia@email.com",
-    bio: "Passionate about technology and continuous learning. Currently specializing in web development and data science.",
-    joinDate: "Enero 2024",
-    location: "Madrid, España",
-    website: "https://anagarcia.dev"
+    name: "",
+    email: "",
+    bio: "",
+    joinDate: "",
+    location: "",
+    website: ""
   });
+
+  useEffect(() => {
+    async function fetchProfile() {
+      try {
+        const userId = '1';
+        const data = await getUser(userId);
+        setProfile({
+          name: data.fullName,
+          email: data.email,
+          bio: "",
+          joinDate: new Date(data.createdAt).toLocaleDateString('es-ES', { month: 'long', year: 'numeric' }),
+          location: "",
+          website: ""
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchProfile();
+  }, []);
 
   const achievements = [
     { id: 1, title: "First Course Completed", description: "Completed your first course", earned: "2024-01-15", icon: BookOpen },
@@ -48,6 +71,11 @@ export default function Profile() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/5 pt-20">
       <div className="container mx-auto px-4 py-8 max-w-6xl">
+        <div className="mb-4">
+          <Button variant="outline" onClick={() => navigate(-1)}>
+            ← Volver
+          </Button>
+        </div>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Profile Sidebar */}
           <div className="lg:col-span-1">

--- a/core/application/usersService.js
+++ b/core/application/usersService.js
@@ -1,0 +1,23 @@
+const users = require('../domain/users');
+const supabase = require('../../shared/utils/supabaseClient');
+
+async function getUserById(id) {
+  if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase
+      .from('users')
+      .select('id, email, full_name, role, created_at')
+      .eq('id', id)
+      .single();
+    if (error) throw error;
+    return {
+      id: data.id,
+      email: data.email,
+      fullName: data.full_name,
+      role: data.role,
+      createdAt: data.created_at,
+    };
+  }
+  return users.find((u) => u.id === id);
+}
+
+module.exports = { getUserById };

--- a/core/domain/users.js
+++ b/core/domain/users.js
@@ -1,0 +1,10 @@
+// In-memory users store for demo
+module.exports = [
+  {
+    id: '1',
+    email: 'ana.garcia@email.com',
+    full_name: 'Ana García',
+    role: 'user',
+    created_at: new Date().toISOString()
+  }
+];

--- a/modules/users/index.js
+++ b/modules/users/index.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const { getUserById } = require('../../core/application/usersService');
+
+router.get('/:id', async (req, res) => {
+  try {
+    const user = await getUserById(req.params.id);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    res.json(user);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create user service and domain model
- add `/users` API route in gateway
- expose `getUser` on frontend API
- fetch backend profile data and add back button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68803308bedc832bae2aed8d14122585