### PR TITLE
Add Stripe webhook handling

### DIFF
--- a/.env
+++ b/.env
@@ -12,3 +12,5 @@ DB_PASSWORD=cjchs123
 
 # Predefined admin accounts (email:password pairs)
 ADMIN_ACCOUNTS=admin1@example.com:adminpass1,admin2@example.com:adminpass2,admin3@example.com:adminpass3
+STRIPE_SECRET_KEY=sk_test_123
+STRIPE_WEBHOOK_SECRET=whsec_test

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DB_USER=postgres
 DB_PASSWORD=postgres
 ADMIN_ACCOUNTS=admin@example.com:password
 STRIPE_SECRET_KEY=sk_test_123
+STRIPE_WEBHOOK_SECRET=whsec_test
 PAYPAL_CLIENT_ID=test
 PAYPAL_CLIENT_SECRET=test
 PORT=8080

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Create a `.env` file in the project root containing the following keys when runn
 - `PORT` – port for the API gateway (defaults to `8080`).
 - `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` – database connection information.
 - `ADMIN_ACCOUNTS` – optional `email:password` pairs for initial admin accounts.
+- `STRIPE_SECRET_KEY` – secret key used to create checkout sessions.
+- `STRIPE_WEBHOOK_SECRET` – signing secret to verify Stripe webhooks.
 
 
 See `.env.example` for an example configuration. When running the Docker container in production you can provide these variables using your orchestrator (for example Cloud Run or `docker run -e`).
@@ -131,3 +133,9 @@ GET /subscriptions/:id
 
 These changes ensure admins share the same subscriptions as regular users and
 any modifications are immediately visible through the API.
+
+## Stripe payments
+
+The `/payments/stripe` endpoint now delegates checkout session creation to a
+Supabase Edge Function. Stripe will call `/payments/stripe/webhook` for events
+using the signing secret defined in `STRIPE_WEBHOOK_SECRET`.

--- a/api-gateway/index.js
+++ b/api-gateway/index.js
@@ -3,6 +3,11 @@ require('../shared/utils/validateEnv')();
 const express = require('express');
 const path = require('path');
 const app = express();
+const { handleStripeWebhook } = require('../modules/payments');
+
+// Raw body parser for Stripe webhooks
+app.post('/payments/stripe/webhook', express.raw({ type: 'application/json' }), handleStripeWebhook);
+
 app.use(express.json());
 
 // Serve built frontend if available

--- a/core/application/paymentsService.js
+++ b/core/application/paymentsService.js
@@ -1,0 +1,32 @@
+const payments = require('../domain/payments');
+const supabase = require('../../shared/utils/supabaseClient');
+
+async function addPayment({ subscriptionId, amount, currency = 'USD', provider, status }) {
+  if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase
+      .from('payments')
+      .insert({
+        subscription_id: subscriptionId,
+        amount,
+        currency,
+        provider,
+        status
+      })
+      .single();
+    if (error) throw error;
+    return data;
+  }
+  const payment = {
+    id: payments.length + 1,
+    subscriptionId,
+    amount,
+    currency,
+    provider,
+    status,
+    paidAt: new Date()
+  };
+  payments.push(payment);
+  return payment;
+}
+
+module.exports = { addPayment };

--- a/core/domain/payments.js
+++ b/core/domain/payments.js
@@ -1,0 +1,3 @@
+// In-memory payments store for demo
+const payments = [];
+module.exports = payments;

--- a/modules/payments/index.js
+++ b/modules/payments/index.js
@@ -1,8 +1,10 @@
 const paymentsRouter = require('./payments');
+const { handleStripeWebhook } = require('./payments');
 const { router: subscriptionsRouter, subscriptions } = require('./subscriptions');
 
 module.exports = {
   paymentsRouter,
   subscriptionsRouter,
-  subscriptions
+  subscriptions,
+  handleStripeWebhook
 };


### PR DESCRIPTION
## Summary
- call Supabase edge function when creating Stripe sessions
- handle Stripe webhook events
- provide payments service and domain model
- document Stripe env vars

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688038277548832b9037f49da723a1ca