### PR TITLE
Switch login to Supabase auth

### DIFF
--- a/api-gateway/public/src/api/index.ts
+++ b/api-gateway/public/src/api/index.ts
@@ -23,3 +23,18 @@ export async function getUser(id: string) {
   }
   return res.json();
 }
+
+export async function loginUser(email: string, password: string) {
+  const res = await fetch(`${API_BASE}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || 'Failed to login');
+  }
+  return data;
+}

--- a/api-gateway/public/src/pages/Login.tsx
+++ b/api-gateway/public/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { GraduationCap, Eye, EyeOff } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
+import { loginUser, getUser } from "@/api";
 
 const Login = () => {
   const [email, setEmail] = useState("");
@@ -22,26 +23,29 @@ const Login = () => {
     setIsLoading(true);
     setError("");
 
-    // Simulación de login - en una app real esto conectaría a tu backend
     try {
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simular delay
-
-      if (email === "demo@learnpro.com" && password === "demo123") {
-        localStorage.setItem("user", JSON.stringify({ 
-          email, 
-          name: "Usuario Demo",
-          isAuthenticated: true 
-        }));
-        toast({
-          title: "¡Bienvenido!",
-          description: "Has iniciado sesión correctamente.",
-        });
-        navigate("/dashboard");
-      } else {
-        setError("Credenciales incorrectas. Usa demo@learnpro.com / demo123");
-      }
+      const { user } = await loginUser(email, password);
+      const details = await getUser(user.id);
+      localStorage.setItem(
+        "user",
+        JSON.stringify({
+          email: details.email,
+          name: details.fullName,
+          role: details.role,
+          isAuthenticated: true,
+        })
+      );
+      toast({
+        title: "¡Bienvenido!",
+        description: "Has iniciado sesión correctamente.",
+      });
+      navigate("/dashboard");
     } catch (err) {
-      setError("Error al iniciar sesión. Inténtalo de nuevo.");
+      if (err instanceof Error) {
+        setError(err.message || "Credenciales incorrectas");
+      } else {
+        setError("Credenciales incorrectas");
+      }
     } finally {
       setIsLoading(false);
     }
@@ -150,9 +154,6 @@ const Login = () => {
           </form>
         </Card>
 
-        <div className="mt-6 text-center text-sm text-muted-foreground">
-          <p>Demo: demo@learnpro.com / demo123</p>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `loginUser` API helper
- connect Login page to Supabase
- remove demo credential text

## Testing
- `npm run lint` (fails on warnings only, no errors)
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68803dc2b0c8832b88f6a798d2dac698