### PR TITLE
Fix Supabase persistence for user registration

### DIFF
--- a/core/application/authService.js
+++ b/core/application/authService.js
@@ -8,7 +8,10 @@ async function register({ email, password, fullName }) {
   const user = data.user;
   if (user) {
     const role = ADMIN_EMAILS.includes(email) ? 'admin' : 'user';
-    await supabase.from('users').insert({ id: user.id, email, full_name: fullName, role });
+    const { error: insertError } = await supabase
+      .from('users')
+      .insert({ id: user.id, email, full_name: fullName, role });
+    if (insertError) throw insertError;
   }
   return user;
 }

--- a/database/supabase-schema.sql
+++ b/database/supabase-schema.sql
@@ -7,18 +7,17 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE IF NOT EXISTS users (
     id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
     email TEXT UNIQUE NOT NULL,
-    password_hash TEXT NOT NULL,
     full_name TEXT,
     role TEXT NOT NULL DEFAULT 'user',
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
 -- Predefined admin accounts
-INSERT INTO users (id, email, password_hash, full_name, role)
+INSERT INTO users (id, email, full_name, role)
 VALUES
-    (uuid_generate_v4(), 'admin1@example.com', '$2b$10$hashedpassword1', 'Admin One', 'admin'),
-    (uuid_generate_v4(), 'admin2@example.com', '$2b$10$hashedpassword2', 'Admin Two', 'admin'),
-    (uuid_generate_v4(), 'admin3@example.com', '$2b$10$hashedpassword3', 'Admin Three', 'admin')
+    (uuid_generate_v4(), 'admin1@example.com', 'Admin One', 'admin'),
+    (uuid_generate_v4(), 'admin2@example.com', 'Admin Two', 'admin'),
+    (uuid_generate_v4(), 'admin3@example.com', 'Admin Three', 'admin')
 ON CONFLICT (email) DO NOTHING;
 
 -- Categories for courses

--- a/shared/utils/supabaseClient.js
+++ b/shared/utils/supabaseClient.js
@@ -1,6 +1,10 @@
 const { createClient } = require('@supabase/supabase-js');
 
 const SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
-const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'local-anon-key';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ANON_KEY = process.env.SUPABASE_ANON_KEY || 'local-anon-key';
 
-module.exports = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+// Prefer service role key so server-side operations bypass RLS restrictions
+const supabaseKey = SERVICE_ROLE_KEY || ANON_KEY;
+
+module.exports = createClient(SUPABASE_URL, supabaseKey);


### PR DESCRIPTION
## Summary
- prefer the service role key for Supabase server-side access
- surface insertion errors when creating users
- drop password_hash from the Supabase schema

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688041ec0d2c832bbbed4c8f42925237