### PR TITLE
Add admin registration

### DIFF
--- a/api-gateway/public/src/App.tsx
+++ b/api-gateway/public/src/App.tsx
@@ -16,6 +16,7 @@ import Contact from "./pages/Contact";
 import NotFound from "./pages/NotFound";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import AdminLogin from "./pages/admin/AdminLogin";
+import AdminRegister from "./pages/admin/AdminRegister";
 import AdminCourses from "./pages/admin/AdminCourses";
 import AdminSubscribers from "./pages/admin/AdminSubscribers";
 import AdminPlans from "./pages/admin/AdminPlans";
@@ -41,6 +42,7 @@ const App = () => (
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
           <Route path="/admin" element={<AdminLogin />} />
+          <Route path="/admin/register" element={<AdminRegister />} />
           <Route path="/admin/dashboard" element={<AdminDashboard />} />
           <Route path="/admin/courses" element={<AdminCourses />} />
           <Route path="/admin/subscribers" element={<AdminSubscribers />} />

--- a/api-gateway/public/src/pages/admin/AdminRegister.tsx
+++ b/api-gateway/public/src/pages/admin/AdminRegister.tsx
@@ -1,63 +1,56 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { GraduationCap, Eye, EyeOff } from "lucide-react";
-import { useNavigate, Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
 
-export default function AdminLogin() {
+export default function AdminRegister() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const navigate = useNavigate();
   const { toast } = useToast();
 
-  useEffect(() => {
-    try {
-      const data = localStorage.getItem("admin");
-      const admin = data ? JSON.parse(data) : null;
-      if (admin?.isAdminAuthenticated) {
-        navigate("/admin/dashboard", { replace: true });
-      }
-    } catch {
-      // ignore json errors
-    }
-  }, [navigate]);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
     setError("");
 
+    if (password.length < 6) {
+      setError("La contraseña debe tener al menos 6 caracteres");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Las contraseñas no coinciden");
+      return;
+    }
+
+    setIsLoading(true);
     try {
-      // Simple client-side credential check since Supabase has been removed
       const stored = localStorage.getItem("adminAccounts");
       const accounts = stored ? JSON.parse(stored) : [];
-      const match = accounts.find(
-        (acc: { email: string; password: string }) =>
-          acc.email === email && acc.password === password
-      );
-
-      if (email === "admin@example.com" && password === "password" || match) {
-        localStorage.setItem(
-          "admin",
-          JSON.stringify({ email, isAdminAuthenticated: true })
-        );
-        toast({
-          title: "¡Bienvenido!",
-          description: "Has iniciado sesión como administrador.",
-        });
-        navigate("/admin/dashboard");
-      } else {
-        setError("Credenciales inválidas");
+      const exists = accounts.some((acc: { email: string }) => acc.email === email);
+      if (exists) {
+        setError("El email ya está registrado");
+        return;
       }
-    } catch (err) {
-      setError("Error al iniciar sesión. Inténtalo de nuevo.");
+      accounts.push({ email, password });
+      localStorage.setItem("adminAccounts", JSON.stringify(accounts));
+      localStorage.setItem("admin", JSON.stringify({ email, isAdminAuthenticated: true }));
+      toast({
+        title: "¡Cuenta creada exitosamente!",
+        description: "Has iniciado sesión como administrador.",
+      });
+      navigate("/admin/dashboard");
+    } catch {
+      setError("Error al crear la cuenta");
     } finally {
       setIsLoading(false);
     }
@@ -75,16 +68,14 @@ export default function AdminLogin() {
           <h1 className="text-3xl font-bold bg-gradient-primary bg-clip-text text-transparent">
             LearnPro Admin
           </h1>
-          <p className="text-muted-foreground mt-2">
-            Accede al panel de administración
-          </p>
+          <p className="text-muted-foreground mt-2">Crea una cuenta de administrador</p>
         </div>
 
         <Card className="border-border shadow-lg">
           <CardHeader className="space-y-1">
-            <CardTitle className="text-2xl text-center">Iniciar Sesión</CardTitle>
+            <CardTitle className="text-2xl text-center">Crear Cuenta Admin</CardTitle>
             <CardDescription className="text-center">
-              Ingresa tus credenciales de administrador
+              Completa los datos para registrarte
             </CardDescription>
           </CardHeader>
 
@@ -115,7 +106,7 @@ export default function AdminLogin() {
                   <Input
                     id="password"
                     type={showPassword ? "text" : "password"}
-                    placeholder="Tu contraseña"
+                    placeholder="Crea una contraseña"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     required
@@ -136,6 +127,34 @@ export default function AdminLogin() {
                   </Button>
                 </div>
               </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">Confirmar contraseña</Label>
+                <div className="relative">
+                  <Input
+                    id="confirmPassword"
+                    type={showConfirmPassword ? "text" : "password"}
+                    placeholder="Confirma tu contraseña"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                    className="border-border pr-10"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <Eye className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </Button>
+                </div>
+              </div>
             </CardContent>
 
             <CardFooter className="flex flex-col space-y-4">
@@ -144,16 +163,13 @@ export default function AdminLogin() {
                 className="w-full bg-gradient-primary hover:opacity-90"
                 disabled={isLoading}
               >
-                {isLoading ? "Iniciando sesión..." : "Iniciar Sesión"}
+                {isLoading ? "Creando cuenta..." : "Crear Cuenta"}
               </Button>
 
               <div className="text-center text-sm text-muted-foreground">
-                ¿No tienes cuenta de administrador?{" "}
-                <Link
-                  to="/admin/register"
-                  className="text-primary hover:underline font-medium"
-                >
-                  Regístrate aquí
+                ¿Ya tienes cuenta?{" "}
+                <Link to="/admin" className="text-primary hover:underline font-medium">
+                  Inicia sesión aquí
                 </Link>
               </div>
             </CardFooter>


### PR DESCRIPTION
## Summary
- support admin registration in AdminLogin
- add a dedicated AdminRegister page
- wire up admin registration route in React app

## Testing
- `npm test` *(fails: no test specified)*
- `cd api-gateway/public && npm run lint` *(fails: 1 error, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68804535e8c0832b8cd4f1808ececc91