### PR TITLE
Update auth to use anon client

### DIFF
--- a/core/application/authService.js
+++ b/core/application/authService.js
@@ -1,9 +1,10 @@
 const supabase = require('../../shared/utils/supabaseClient');
+const supabaseAuthClient = require('../../shared/utils/supabaseAuthClient');
 
 const ADMIN_EMAILS = process.env.ADMIN_EMAILS ? process.env.ADMIN_EMAILS.split(',') : [];
 
 async function register({ email, password, fullName }) {
-  const { data, error } = await supabase.auth.signUp({ email, password });
+  const { data, error } = await supabaseAuthClient.auth.signUp({ email, password });
   if (error) throw error;
   const user = data.user;
   if (user) {
@@ -17,7 +18,7 @@ async function register({ email, password, fullName }) {
 }
 
 async function login({ email, password }) {
-  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  const { data, error } = await supabaseAuthClient.auth.signInWithPassword({ email, password });
   if (error) throw error;
   return data;
 }

--- a/shared/utils/supabaseAuthClient.js
+++ b/shared/utils/supabaseAuthClient.js
@@ -1,0 +1,6 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+const ANON_KEY = process.env.SUPABASE_ANON_KEY || 'local-anon-key';
+
+module.exports = createClient(SUPABASE_URL, ANON_KEY);


### PR DESCRIPTION
## Summary
- add `supabaseAuthClient` utility that always uses `SUPABASE_ANON_KEY`
- update `authService` to authenticate with `supabaseAuthClient`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68804d1b419c832ba7924447a8ef0bc9