### PR TITLE
Design email notifications

### DIFF
--- a/core/application/notificationsService.js
+++ b/core/application/notificationsService.js
@@ -1,6 +1,7 @@
 const notifications = require('../domain/notifications');
 const supabase = require('../../shared/utils/supabaseClient');
 const resend = require('../../shared/utils/resendClient');
+const buildNotificationEmailHTML = require('../../shared/templates/notificationEmailTemplate');
 const { getUserById } = require('./usersService');
 
 async function sendEmailNotification(userId, message) {
@@ -12,7 +13,8 @@ async function sendEmailNotification(userId, message) {
         from: 'no-reply@learnpro.com',
         to: user.email,
         subject: 'LearnPro Notification',
-        text: message
+        text: message,
+        html: buildNotificationEmailHTML(message)
       });
     }
   } catch (err) {

--- a/shared/templates/notificationEmailTemplate.js
+++ b/shared/templates/notificationEmailTemplate.js
@@ -1,0 +1,13 @@
+function buildNotificationEmailHTML(message) {
+  return `
+  <div style="font-family: Arial, sans-serif; background-color: #f8fafc; padding: 20px;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); padding: 20px;">
+      <h2 style="color: #4f46e5; margin-top: 0;">LearnPro Notification</h2>
+      <p style="font-size: 16px; line-height: 1.4;">${message}</p>
+      <p style="margin-top: 24px; font-size: 14px; color: #64748b;">Thank you for using LearnPro.</p>
+    </div>
+  </div>
+  `;
+}
+
+module.exports = buildNotificationEmailHTML;


### PR DESCRIPTION
## Summary
- add HTML template for Resend emails
- send styled HTML email on notifications

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688059eb8f78832ba727daaeed7ec83c