### PR TITLE
Fix missing progress API function

### DIFF
--- a/api-gateway/public/src/api/index.ts
+++ b/api-gateway/public/src/api/index.ts
@@ -97,3 +97,11 @@ export async function getSubscriptions() {
   }
   return res.json();
 }
+
+export async function getUserProgress(userId: string) {
+  const res = await fetch(`${API_BASE}/progress/${userId}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch user progress');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- export new `getUserProgress` helper in the frontend API client

## Testing
- `npm run build` in `api-gateway/public`
- `npm run lint` in `api-gateway/public` *(fails: Unexpected any, only-export-components)*

------
https://chatgpt.com/codex/tasks/task_e_688062f06f50832b8033d5f6e2860948