### PR TITLE
Add plans and categories CRUD with Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,25 @@ DELETE /subscriptions/:id  # remove a subscription
 All users (including admins) can retrieve subscriptions with:
 
 ```
-GET /subscriptions/:id
+  GET /subscriptions/:id
 ```
+
+## Plan management
+
+Plans define the subscription options available for users. The API now exposes
+CRUD operations under `/plans`. Creating, updating or deleting a plan requires
+the `x-user-role: admin` header:
+
+```
+GET /plans            # list plans
+POST /plans           # create plan
+GET /plans/:id        # get plan by id
+PUT /plans/:id        # update plan
+DELETE /plans/:id     # remove plan
+```
+
+Similarly, categories can be created and edited through `/categories` using the
+same admin header.
 
 These changes ensure admins share the same subscriptions as regular users and
 any modifications are immediately visible through the API.

--- a/api-gateway/index.js
+++ b/api-gateway/index.js
@@ -33,10 +33,12 @@ const notificationsRouter = require('../modules/notifications');
 const progressRouter = require('../modules/products/progress');
 const usersRouter = require('../modules/users');
 const categoriesRouter = require('../modules/categories');
+const plansRouter = require('../modules/plans');
 app.use("/products", subscriptionAccess, productsRouter);
 app.use("/progress", subscriptionAccess, progressRouter);
 
 app.use('/categories', categoriesRouter);
+app.use('/plans', plansRouter);
 
 app.use("/payments", paymentsRouter);
 app.use('/subscriptions', subscriptionsRouter);

--- a/core/application/categoriesService.js
+++ b/core/application/categoriesService.js
@@ -14,4 +14,66 @@ async function getAllCategories() {
   return categories;
 }
 
-module.exports = { getAllCategories };
+async function getCategoryById(id) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    const { rows } = await db.query('SELECT * FROM categories WHERE id=$1', [id]);
+    return rows[0] || null;
+  } else if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase.from('categories').select('*').eq('id', id).single();
+    if (error) return null;
+    return data;
+  }
+  return categories.find(c => c.id === parseInt(id, 10)) || null;
+}
+
+async function addCategory({ name }) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    const { rows } = await db.query('INSERT INTO categories (name) VALUES ($1) RETURNING *', [name]);
+    return rows[0];
+  } else if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase.from('categories').insert({ name }).single();
+    if (error) throw error;
+    return data;
+  }
+  const category = { id: categories.length + 1, name };
+  categories.push(category);
+  return category;
+}
+
+async function updateCategory(id, { name }) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    const { rows } = await db.query('UPDATE categories SET name=$1 WHERE id=$2 RETURNING *', [name, id]);
+    return rows[0];
+  } else if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase.from('categories').update({ name }).eq('id', id).single();
+    if (error) throw error;
+    return data;
+  }
+  const category = categories.find(c => c.id === parseInt(id, 10));
+  if (!category) return null;
+  category.name = name;
+  return category;
+}
+
+async function deleteCategory(id) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    await db.query('DELETE FROM categories WHERE id=$1', [id]);
+    return true;
+  } else if (process.env.SUPABASE_URL) {
+    const { error } = await supabase.from('categories').delete().eq('id', id);
+    if (error) throw error;
+    return true;
+  }
+  const index = categories.findIndex(c => c.id === parseInt(id, 10));
+  if (index === -1) return false;
+  categories.splice(index, 1);
+  return true;
+}
+
+module.exports = {
+  getAllCategories,
+  getCategoryById,
+  addCategory,
+  updateCategory,
+  deleteCategory
+};

--- a/core/application/plansService.js
+++ b/core/application/plansService.js
@@ -1,0 +1,95 @@
+const plans = require('../domain/plans');
+const supabase = require('../../shared/utils/supabaseClient');
+const db = require('../../shared/utils/db');
+
+async function getAllPlans() {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    const { rows } = await db.query('SELECT * FROM plans');
+    return rows;
+  } else if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase.from('plans').select('*');
+    if (error) throw error;
+    return data;
+  }
+  return plans;
+}
+
+async function getPlanById(id) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    const { rows } = await db.query('SELECT * FROM plans WHERE id=$1', [id]);
+    return rows[0] || null;
+  } else if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase.from('plans').select('*').eq('id', id).single();
+    if (error) return null;
+    return data;
+  }
+  return plans.find(p => p.id === parseInt(id, 10)) || null;
+}
+
+async function addPlan({ name, price, period, description }) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    const { rows } = await db.query(
+      'INSERT INTO plans (name, price, period, description) VALUES ($1,$2,$3,$4) RETURNING *',
+      [name, price, period, description]
+    );
+    return rows[0];
+  } else if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase
+      .from('plans')
+      .insert({ name, price, period, description })
+      .single();
+    if (error) throw error;
+    return data;
+  }
+  const plan = { id: plans.length + 1, name, price, period, description };
+  plans.push(plan);
+  return plan;
+}
+
+async function updatePlan(id, { name, price, period, description }) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    const { rows } = await db.query(
+      'UPDATE plans SET name=$1, price=$2, period=$3, description=$4 WHERE id=$5 RETURNING *',
+      [name, price, period, description, id]
+    );
+    return rows[0];
+  } else if (process.env.SUPABASE_URL) {
+    const { data, error } = await supabase
+      .from('plans')
+      .update({ name, price, period, description })
+      .eq('id', id)
+      .single();
+    if (error) throw error;
+    return data;
+  }
+  const plan = plans.find(p => p.id === parseInt(id, 10));
+  if (!plan) return null;
+  if (name !== undefined) plan.name = name;
+  if (price !== undefined) plan.price = price;
+  if (period !== undefined) plan.period = period;
+  if (description !== undefined) plan.description = description;
+  return plan;
+}
+
+async function deletePlan(id) {
+  if (process.env.DATABASE_URL || process.env.DB_HOST) {
+    await db.query('DELETE FROM plans WHERE id=$1', [id]);
+    return true;
+  } else if (process.env.SUPABASE_URL) {
+    const { error } = await supabase.from('plans').delete().eq('id', id);
+    if (error) throw error;
+    return true;
+  }
+  const index = plans.findIndex(p => p.id === parseInt(id, 10));
+  if (index === -1) return false;
+  plans.splice(index, 1);
+  return true;
+}
+
+module.exports = {
+  getAllPlans,
+  getPlanById,
+  addPlan,
+  updatePlan,
+  deletePlan
+};

--- a/core/domain/plans.js
+++ b/core/domain/plans.js
@@ -1,0 +1,23 @@
+module.exports = [
+  {
+    id: 1,
+    name: 'Basic',
+    price: 29,
+    period: '1 month',
+    description: 'Acceso a 5 cursos'
+  },
+  {
+    id: 2,
+    name: 'Premium',
+    price: 79,
+    period: '1 month',
+    description: 'Acceso a todos los cursos'
+  },
+  {
+    id: 3,
+    name: 'Enterprise',
+    price: 199,
+    period: '1 month',
+    description: 'Para equipos y organizaciones'
+  }
+];

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -160,6 +160,72 @@ paths:
       responses:
         '200':
           description: Category list
+    post:
+      summary: Create category
+      parameters:
+        - in: header
+          name: x-user-role
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Category created
+  /categories/{id}:
+    get:
+      summary: Get category by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Category details
+        '404':
+          description: Category not found
+    put:
+      summary: Update category
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: header
+          name: x-user-role
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Category updated
+    delete:
+      summary: Delete category
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: header
+          name: x-user-role
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Category deleted
   /users/{id}:
     get:
       summary: Get user by id
@@ -299,3 +365,75 @@ paths:
       responses:
         '201':
           description: Notification created
+  /plans:
+    get:
+      summary: List plans
+      responses:
+        '200':
+          description: Plan list
+    post:
+      summary: Create plan
+      parameters:
+        - in: header
+          name: x-user-role
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Plan created
+  /plans/{id}:
+    get:
+      summary: Get plan
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Plan data
+        '404':
+          description: Plan not found
+    put:
+      summary: Update plan
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: header
+          name: x-user-role
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Plan updated
+    delete:
+      summary: Delete plan
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: header
+          name: x-user-role
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Plan deleted

--- a/modules/plans/index.js
+++ b/modules/plans/index.js
@@ -1,18 +1,18 @@
 const express = require('express');
 const router = express.Router();
 const {
-  getAllCategories,
-  getCategoryById,
-  addCategory,
-  updateCategory,
-  deleteCategory
-} = require('../../core/application/categoriesService');
+  getAllPlans,
+  getPlanById,
+  addPlan,
+  updatePlan,
+  deletePlan
+} = require('../../core/application/plansService');
 const adminAccess = require('../../shared/middleware/adminAccess');
 
 router.get('/', async (req, res) => {
   try {
-    const categories = await getAllCategories();
-    res.json(categories);
+    const plans = await getAllPlans();
+    res.json(plans);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -20,8 +20,8 @@ router.get('/', async (req, res) => {
 
 router.post('/', adminAccess, async (req, res) => {
   try {
-    const category = await addCategory(req.body);
-    res.status(201).json(category);
+    const plan = await addPlan(req.body);
+    res.status(201).json(plan);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -29,9 +29,9 @@ router.post('/', adminAccess, async (req, res) => {
 
 router.get('/:id', async (req, res) => {
   try {
-    const category = await getCategoryById(req.params.id);
-    if (!category) return res.status(404).json({ error: 'Not found' });
-    res.json(category);
+    const plan = await getPlanById(req.params.id);
+    if (!plan) return res.status(404).json({ error: 'Not found' });
+    res.json(plan);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -39,9 +39,9 @@ router.get('/:id', async (req, res) => {
 
 router.put('/:id', adminAccess, async (req, res) => {
   try {
-    const category = await updateCategory(req.params.id, req.body);
-    if (!category) return res.status(404).json({ error: 'Not found' });
-    res.json(category);
+    const plan = await updatePlan(req.params.id, req.body);
+    if (!plan) return res.status(404).json({ error: 'Not found' });
+    res.json(plan);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -49,7 +49,7 @@ router.put('/:id', adminAccess, async (req, res) => {
 
 router.delete('/:id', adminAccess, async (req, res) => {
   try {
-    const success = await deleteCategory(req.params.id);
+    const success = await deletePlan(req.params.id);
     if (!success) return res.status(404).json({ error: 'Not found' });
     res.json({ success: true });
   } catch (err) {


### PR DESCRIPTION
## Summary
- implement full CRUD for categories
- add plans domain, service and routes
- expose `/plans` routes in API gateway
- update Swagger documentation and README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68838b5554b8832bba2eab126acc994a