### PR TITLE
Add intro video URL field

### DIFF
--- a/core/application/coursesService.js
+++ b/core/application/coursesService.js
@@ -34,37 +34,37 @@ async function getCourseById(id) {
   return courses.find(c => c.id === id);
 }
 
-async function addCourse({ title, description, plan }) {
+async function addCourse({ title, description, plan, intro_video_url }) {
   if (process.env.DATABASE_URL || process.env.DB_HOST) {
     const { rows } = await db.query(
-      'INSERT INTO courses (title, description, plan_id) VALUES ($1,$2,$3) RETURNING *',
-      [title, description, plan]
+      'INSERT INTO courses (title, description, plan_id, intro_video_url) VALUES ($1,$2,$3,$4) RETURNING *',
+      [title, description, plan, intro_video_url]
     );
     return rows[0];
   } else if (process.env.SUPABASE_URL) {
     const { data, error } = await supabase
       .from('courses')
-      .insert({ title, description, plan_id: plan })
+      .insert({ title, description, plan_id: plan, intro_video_url })
       .single();
     if (error) throw error;
     return data;
   }
-  const course = { id: courses.length + 1, title, description, plan };
+  const course = { id: courses.length + 1, title, description, plan, intro_video_url };
   courses.push(course);
   return course;
 }
 
-async function updateCourse(id, { title, description, plan }) {
+async function updateCourse(id, { title, description, plan, intro_video_url }) {
   if (process.env.DATABASE_URL || process.env.DB_HOST) {
     const { rows } = await db.query(
-      'UPDATE courses SET title=$1, description=$2, plan_id=$3 WHERE id=$4 RETURNING *',
-      [title, description, plan, id]
+      'UPDATE courses SET title=$1, description=$2, plan_id=$3, intro_video_url=$4 WHERE id=$5 RETURNING *',
+      [title, description, plan, intro_video_url, id]
     );
     return rows[0];
   } else if (process.env.SUPABASE_URL) {
     const { data, error } = await supabase
       .from('courses')
-      .update({ title, description, plan_id: plan })
+      .update({ title, description, plan_id: plan, intro_video_url })
       .eq('id', id)
       .single();
     if (error) throw error;
@@ -75,6 +75,7 @@ async function updateCourse(id, { title, description, plan }) {
   if (title !== undefined) course.title = title;
   if (description !== undefined) course.description = description;
   if (plan !== undefined) course.plan = plan;
+  if (intro_video_url !== undefined) course.intro_video_url = intro_video_url;
   return course;
 }
 

--- a/core/domain/courses.js
+++ b/core/domain/courses.js
@@ -5,20 +5,23 @@ const courses = [
     title: 'JavaScript Moderno: ES6+',
     description:
       'Aprende las caracter\u00edsticas m\u00e1s recientes de JavaScript incluyendo ES6, ES7 y m\u00e1s all\u00e1.',
-    plan: 'basic'
+    plan: 'basic',
+    intro_video_url: 'https://example.com/js-intro.mp4'
   },
   {
     id: 2,
     title: 'React Avanzado',
     description:
       'Domina React con hooks, context, suspense y las mejores pr\u00e1cticas de desarrollo.',
-    plan: 'premium'
+    plan: 'premium',
+    intro_video_url: 'https://example.com/react-intro.mp4'
   },
   {
     id: 3,
     title: 'Node.js y Express',
     description: 'Desarrolla APIs robustas y aplicaciones backend con Node.js y Express.',
-    plan: 'premium'
+    plan: 'premium',
+    intro_video_url: 'https://example.com/node-intro.mp4'
   }
 ];
 module.exports = courses;

--- a/database/supabase-schema.sql
+++ b/database/supabase-schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS courses (
     title TEXT NOT NULL,
     description TEXT,
     image_url TEXT,
+    intro_video_url TEXT,
     instructor TEXT,
     duration TEXT,
     students INTEGER,

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -77,6 +77,8 @@ paths:
                   type: string
                 plan:
                   type: string
+                intro_video_url:
+                  type: string
       responses:
         '201':
           description: Course created
@@ -112,6 +114,9 @@ paths:
           application/json:
             schema:
               type: object
+              properties:
+                intro_video_url:
+                  type: string
       responses:
         '200':
           description: Course updated

--- a/modules/products/index.js
+++ b/modules/products/index.js
@@ -36,8 +36,8 @@ router.get('/:id', async (req, res) => {
 
 router.post('/', adminAccess, async (req, res) => {
   try {
-    const { title, description, plan } = req.body;
-    const course = await addCourse({ title, description, plan });
+    const { title, description, plan, intro_video_url } = req.body;
+    const course = await addCourse({ title, description, plan, intro_video_url });
     res.status(201).json(course);
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- allow specifying `intro_video_url` for courses
- add `intro_video_url` column to SQL schema
- document new field in Swagger
- expose field in the products API
- include placeholder URLs in demo data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888e114a4ec832b8540f156d5da598e